### PR TITLE
Explicit strict_supports in tests

### DIFF
--- a/tests/test_octodns_provider_mythicbeasts.py
+++ b/tests/test_octodns_provider_mythicbeasts.py
@@ -391,7 +391,9 @@ class TestMythicBeastsProvider(TestCase):
             self.assertEqual(0, len(changes))
 
     def test_apply(self):
-        provider = MythicBeastsProvider('test', {'unit.tests.': 'mypassword'})
+        provider = MythicBeastsProvider(
+            'test', {'unit.tests.': 'mypassword'}, strict_supports=False
+        )
         zone = Zone('unit.tests.', [])
 
         # Create blank zone


### PR DESCRIPTION
As of https://github.com/octodns/octodns/pull/957 we'll need t be explicit in our tests around the expectations of `Provider.strict_supports`. This PR is in preparation of that change. 

/cc https://github.com/octodns/octodns/pull/957