### PR TITLE
Version 1.0.0 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.2 - 20??-??-?? - ???
+## v1.0.0 - 2025-05-04 - 1.0
 
 * Address pending octoDNS 2.x deprecations, require minimum of 1.5.x
 

--- a/octodns_mythicbeasts/__init__.py
+++ b/octodns_mythicbeasts/__init__.py
@@ -14,7 +14,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.1'
+__version__ = __VERSION__ = '1.0.0'
 
 
 def add_trailing_dot(value):


### PR DESCRIPTION
## v1.0.0 - 2025-05-04 - 1.0

* Address pending octoDNS 2.x deprecations, require minimum of 1.5.x