### PR TITLE
Fix to allow non-apex ALIAS records

### DIFF
--- a/octodns_mythicbeasts/__init__.py
+++ b/octodns_mythicbeasts/__init__.py
@@ -364,6 +364,7 @@ class MythicBeastsProvider(BaseProvider):
                     _name,
                     data_for(_type, data[_type][_name]),
                     source=self,
+                    lenient=lenient
                 )
                 zone.add_record(record, lenient=lenient)
 


### PR DESCRIPTION
octodns-sync can create them, but then errors every other time

```
✔ ➜  oktodns git:(main) ✗ octodns-sync --config-file config/mythic.yaml --quiet --doit
2026-03-03T14:28:57  [8477303296] WARNING Record Invalid record "alias.domain.com.", ./resources/domain.com.yaml, line 152, column 3
  - non-root ALIAS not allowed
2026-03-03T14:28:58  [8477303296] INFO    Plan 
********************************************************************************
* domain.com.
********************************************************************************
* mythicbeasts (MythicBeastsProvider)
*   Create <AliasRecord ALIAS 300, alias.domain.com., destination.domain.com., {'lenient': True}> (config)
*   Summary: Creates=1, Updates=0, Deletes=0, Existing=57, Meta=False
********************************************************************************
```

```
✔ ➜  oktodns git:(main) ✗ octodns-sync --config-file config/mythic.yaml --quiet --doit
2026-03-03T14:29:08  [8477303296] WARNING Record Invalid record "alias.domain.com.", ./resources/alias.domain.com.yaml, line 152, column 3
  - non-root ALIAS not allowed
Traceback (most recent call last):
  File "/Users/james/repos/oktodns/config/.env/bin/octodns-sync", line 6, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/james/repos/oktodns/config/.env/lib/python3.14/site-packages/octodns/cmds/sync.py", line 62, in main
    manager.sync(
    ~~~~~~~~~~~~^
        eligible_zones=args.zone,
        ^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<4 lines>...
        checksum=args.checksum,
        ^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/james/repos/oktodns/config/.env/lib/python3.14/site-packages/octodns/manager.py", line 835, in sync
    ps, d = future.result()
            ~~~~~~~~~~~~~^^
  File "/Users/james/repos/oktodns/config/.env/lib/python3.14/site-packages/octodns/manager.py", line 65, in result
    return self.func(*self.args, **self.kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/james/repos/oktodns/config/.env/lib/python3.14/site-packages/octodns/manager.py", line 536, in _populate_and_plan
    plan = target.plan(zone, processors=processors)
  File "/Users/james/repos/oktodns/config/.env/lib/python3.14/site-packages/octodns/provider/base.py", line 426, in plan
    exists = self.populate(existing, target=True, lenient=True)
  File "/Users/james/repos/oktodns/config/.env/lib/python3.14/site-packages/octodns_mythicbeasts/__init__.py", line 362, in populate
    record = Record.new(
        zone,
    ...<2 lines>...
        source=self,
    )
  File "/Users/james/repos/oktodns/config/.env/lib/python3.14/site-packages/octodns/record/base.py", line 84, in new
    raise ValidationError(fqdn, reasons, context)
octodns.record.exception.ValidationError: Invalid record "alias.domain.com."
  - non-root ALIAS not allowed
```