### PR TITLE
Explicit non-escaped semicolons for YamlProvider

### DIFF
--- a/.changelog/873a3af93a3244aaa8630e11946b3562.md
+++ b/.changelog/873a3af93a3244aaa8630e11946b3562.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Explicit non-escaped semicolons for YamlProvider

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -151,7 +151,7 @@ txt:
   values:
     - Bah bah black sheep
     - have you any wool.
-    - 'v=DKIM1\;k=rsa\;s=email\;h=sha256\;p=A/kinda+of/long/string+with+numb3rs'
+    - 'v=DKIM1;k=rsa;s=email;h=sha256;p=A/kinda+of/long/string+with+numb3rs'
 urlfwd:
   ttl: 300
   type: URLFWD

--- a/tests/test_octodns_provider_mythicbeasts.py
+++ b/tests/test_octodns_provider_mythicbeasts.py
@@ -21,7 +21,11 @@ from octodns_mythicbeasts import (
 
 class TestMythicBeastsProvider(TestCase):
     expected = Zone('unit.tests.', [])
-    source = YamlProvider('test_expected', join(dirname(__file__), 'config'))
+    source = YamlProvider(
+        'test_expected',
+        join(dirname(__file__), 'config'),
+        escaped_semicolons=False,
+    )
     source.populate(expected)
 
     # Dump anything we don't support from expected


### PR DESCRIPTION
YamlProvider is going to default to escaped_semicolons=False in 2.x, until then we'll explicitly ask for it to get tests happy w/o the deprecated warning.

/cc https://github.com/octodns/octodns/pull/1419